### PR TITLE
chore: add MIT license, CI workflow and run instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main, dev ]
+  push:
+    branches: [ main, dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Build
+        run: npm run build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 chamodipiyadasa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,54 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## EmailJS setup (contact form)
+
+If you configured EmailJS for the contact form, add the following env vars to a `.env` file at the project root (restart Vite after editing):
+
+```
+VITE_EMAILJS_SERVICE_ID=service_xxxxxx
+VITE_EMAILJS_TEMPLATE_ID=template_xxxxxx
+VITE_EMAILJS_PUBLIC_KEY=user_xxxxxxxx
+```
+
+Create an EmailJS template that uses these variables: `from_name`, `from_email`, `message`.
+
+Recommended EmailJS template subject:
+
+```
+New message from {{from_name}} — Portfolio
+```
+
+HTML body (example):
+
+```html
+<h1>New message from {{from_name}}</h1>
+<p>From: <a href="mailto:{{from_email}}">{{from_email}}</a></p>
+<pre>{{message}}</pre>
+```
+
+Quick test flow
+- Install deps and start dev server: `npm install` then `npm run dev`.
+- Open the site, fill the contact form and click Send.
+- Check EmailJS Dashboard → Email Logs if the message doesn't arrive.
+
+Security note: the EmailJS Public Key (`user_xxx`) is intended for client use. Never expose private/server keys in the frontend or commit them to a public repo.
+
+## How to run locally
+
+Clone the repo and run the following commands to start the development server locally:
+
+```bash
+git clone <your-repo-url>
+cd portfolio
+npm install
+# create a .env with your EmailJS keys (see above)
+npm run dev
+```
+
+Open the URL printed by Vite (usually http://localhost:5173) and verify the site loads. To test the contact form you must set the EmailJS env variables in `.env` as described above.
+
+## License
+
+This project is available under the MIT License — see the `LICENSE` file for details.

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -62,7 +62,7 @@ export const ContactSection = () => {
       if (!newWindow && navigator.clipboard) {
         navigator.clipboard.writeText(mailto).catch(() => {})
       }
-    } catch (err) {
+    } catch {
       if (navigator.clipboard) {
         navigator.clipboard.writeText(mailto).catch(() => {})
       }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from "@tailwindcss/vite"
-import path from 'path';
+import path from 'path'
+import { fileURLToPath } from 'url'
 
+// Fix __dirname in ESM
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -10,6 +14,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-    }}
+    }
+  }
 })
-


### PR DESCRIPTION
Summary

Adds a permissive MIT [LICENSE](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Adds a minimal GitHub Actions workflow: [ci.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) that runs on push/PR to [main](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and dev and executes npm ci, npm run lint (if present) and npm run build.
Updates [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with local run instructions and a License section, plus EmailJS setup reminders.
Files changed

LICENSE (new)
[ci.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (new)
[README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (updated)